### PR TITLE
makeurl functionality now uses http_build_query

### DIFF
--- a/src/FoursquareAPI.class.php
+++ b/src/FoursquareAPI.class.php
@@ -237,12 +237,7 @@ class FoursquareApi {
 	 * @param Array $params The parameters to pass to the URL
 	 */	
 	private function MakeUrl($url,$params){
-		if(!empty($params) && $params){
-			foreach($params as $k=>$v) $kv[] = "$k=$v";
-			$url_params = str_replace(" ","+",implode('&',$kv));
-			$url = trim($url) . '?' . $url_params;
-		}
-		return $url;
+	    return trim($url) . '?' . http_build_query($params); 
 	}
 	
 	// Access token functions


### PR DESCRIPTION
**As requested by Arjan Haverkamp:**

I am using a redirect-uri with a question mark in it, something like this: http://mysite.com/auth/foursquare/?authDone=1.

When I use this redirect_uri with your class, Foursquare keeps complaining about a "redirect_uri_mismatch". It took me quite some time to figure out where the problem was, but I did eventually manage to find it.

Your 'MakeURL' function is not properly url-encoding the question mark in the redirect-uri.
